### PR TITLE
perf: avoid using regex in contains_cjk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ clap = { version = "4.5.36", features = ["derive"] }
 directories-next = "2.0.0"
 indicatif = "0.17.11"
 owo-colors = "4.2.0"
-regex = "1.11.1"
 reqwest = { version = "0.12.15", features = ["blocking", "json", "rustls-tls"], default-features = false }
 rusqlite = { version = "0.35.0", features = ["bundled"] }
 rustyline = "15.0.0"

--- a/src/rdict.rs
+++ b/src/rdict.rs
@@ -2,7 +2,6 @@ use crate::parse::{ToChinese, ToEnglish, to_chinese, to_english};
 use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use owo_colors::OwoColorize;
-use regex::Regex;
 use reqwest::blocking::Client;
 use rustyline::DefaultEditor;
 use std::collections::HashMap;
@@ -247,8 +246,8 @@ impl Rdict {
     }
 
     pub fn contains_cjk(word: &str) -> bool {
-        let re = Regex::new(r"[\p{Han}]").unwrap();
-        re.is_match(word)
+        word.chars()
+            .any(|ch| ('\u{4E00}'..='\u{9FFF}').contains(&ch))
     }
 }
 


### PR DESCRIPTION
| Command                        | Mean [ms] | Min [ms] | Max [ms] |    Relative |
| :----------------------------- | --------: | -------: | -------: | ----------: |
| `rdict hello`                  | 1.6 ± 0.2 |      1.2 |      3.9 | 1.25 ± 0.26 |
| `./target/release/rdict hello` | 1.3 ± 0.2 |      0.9 |      2.8 |        1.00 |